### PR TITLE
Multiple "--header" arguments suppport

### DIFF
--- a/chisel/templates/deployment.yaml
+++ b/chisel/templates/deployment.yaml
@@ -91,7 +91,13 @@ spec:
             - --proxy={{ .Values.args.proxy }}
             {{- end }}
             {{- if .Values.args.header }}
-            - --header={{ .Values.args.header }}
+              {{- if (.Values.args.header | kindIs "string") }}
+            - "--header={{ .Values.args.header }}"
+              {{- else }}
+                {{- range $header := .Values.args.header }}
+            - "--header={{ $header }}"
+                {{- end }}
+              {{- end }}
             {{- end }}
             {{- if .Values.args.hostname }}
             - --hostname={{ .Values.args.hostname }}

--- a/chisel/templates/secrets.yaml
+++ b/chisel/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.mode "server") .Values.args.auth .Values.args.fingerprint }}
+{{- if or (eq .Values.mode "server") .Values.args.auth .Values.args.fingerprint .Values.credentials }}
 ---
 apiVersion: v1
 kind: Secret


### PR DESCRIPTION
Hi.

I hope you're having a great day.

In order to connect to our Chisel server, the client must include two headers in their request  before they can get past the edge security service we use.  To achieve this, and to fix a couple of minor quirks that might be specific to my deployment, I have modified your fine helm chart in the following ways:

* Modify Deployment so that args.header can be an array or string.
* Modify Deployment so the entire --header argument is quoted.
* Modify Secret so it is also created if ".Values.credentials" is defined

I don't expect any of these changes will impact any existing deployments.

Cheers.
Shaun.

Sponsored-by: Orro Group