### PR TITLE
Fix secret creation when a credentials.password is set

### DIFF
--- a/chisel/Chart.yaml
+++ b/chisel/Chart.yaml
@@ -25,4 +25,4 @@ version: 0.0.4
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
-appVersion: 1.7.6
+appVersion: 1.10.0

--- a/chisel/templates/secrets.yaml
+++ b/chisel/templates/secrets.yaml
@@ -1,4 +1,4 @@
-{{- if or (eq .Values.mode "server") .Values.args.auth .Values.args.fingerprint }}
+{{- if or (eq .Values.mode "server") .Values.args.auth .Values.args.fingerprint .Values.credentials.password }}
 ---
 apiVersion: v1
 kind: Secret

--- a/chisel/values.yaml
+++ b/chisel/values.yaml
@@ -16,6 +16,9 @@ image:
   tag: ""
   customRegistry: #registry.myorg.com
 
+credentials:
+  password: ""
+
 imagePullSecrets: []
 nameOverride: ""
 fullnameOverride: ""


### PR DESCRIPTION
It adds a new condition to render the secret template, also added a default empty credentials.password to avoid error:

Error: INSTALLATION FAILED: template: chisel/templates/secrets.yaml:1:87: executing "chisel/templates/secrets.yaml" at <.Values.credentials.password>: nil pointer evaluating interface {}.password
Note: Please add topic #hacktoberfest to the repo and label hacktoberfest-accepted to this PR/MR.